### PR TITLE
Fix parsing lines using -e and end of line comments

### DIFF
--- a/requirements/requirement.py
+++ b/requirements/requirement.py
@@ -94,6 +94,10 @@ class Requirement(object):
 
         req = cls('-e {0}'.format(line))
         req.editable = True
+
+        if ' #' in line:
+            line = line[:line.find(' #')]
+
         vcs_match = VCS_REGEX.match(line)
         local_match = LOCAL_REGEX.match(line)
 

--- a/tests/reqfiles/editable_2.expected
+++ b/tests/reqfiles/editable_2.expected
@@ -1,0 +1,54 @@
+[
+ {
+  "specifier": false,
+  "local_file": false,
+  "name": "MyProject",
+  "editable": true,
+  "uri": "svn+svn://svn.myproject.org/svn/MyProject",
+  "extras": [],
+  "vcs": "svn",
+  "path": null,
+  "line": "-e svn+svn://svn.myproject.org/svn/MyProject#egg=MyProject # Test comment",
+  "specs": [],
+  "revision": null
+ },
+ {
+  "specifier": false,
+  "local_file": false,
+  "name": "MyProject",
+  "editable": true,
+  "uri": "git://git.myproject.org/MyProject.git",
+  "extras": [],
+  "vcs": "git",
+  "path": null,
+  "line": "-e git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709#egg=MyProject # Test comment",
+  "specs": [],
+  "revision": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+ },
+ {
+  "specifier": false,
+  "local_file": false,
+  "name": "MyProject",
+  "editable": true,
+  "uri": "hg+http://hg.myproject.org/MyProject/",
+  "extras": [],
+  "vcs": "hg",
+  "path": null,
+  "line": "-e hg+http://hg.myproject.org/MyProject/@special_feature#egg=MyProject # Test comment",
+  "specs": [],
+  "revision": "special_feature"
+ },
+ {
+  "specifier": false,
+  "local_file": false,
+  "name": "MyProject",
+  "editable": true,
+  "uri": "bzr+lp://MyProject",
+  "extras": [],
+  "vcs": "bzr",
+  "path": null,
+  "line": "-e bzr+lp://MyProject#egg=MyProject # Test comment",
+  "specs": [],
+  "revision": null
+ }
+]

--- a/tests/reqfiles/editable_2.txt
+++ b/tests/reqfiles/editable_2.txt
@@ -1,0 +1,4 @@
+-e svn+svn://svn.myproject.org/svn/MyProject#egg=MyProject # Test comment
+--editable git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709#egg=MyProject # Test comment
+--editable hg+http://hg.myproject.org/MyProject/@special_feature#egg=MyProject # Test comment
+-e bzr+lp://MyProject#egg=MyProject # Test comment


### PR DESCRIPTION
This is what I noticed when working with #25. I think this is the more proper fix. The test files are the same as editable_1, but with `# Test comment` on the end of all of them.
