### PR TITLE
Adds equality (and inequality) testing to Requirement class

### DIFF
--- a/requirements/requirement.py
+++ b/requirements/requirement.py
@@ -82,6 +82,21 @@ class Requirement(object):
     def __getitem__(self, key):
         return getattr(self, key)
 
+    def __eq__(self, other):
+        return all([
+            self.name == other.name,
+            set(self.specs) == set(other.specs),
+            self.editable == other.editable,
+            self.specifier == other.specifier,
+            self.revision == other.revision,
+            self.hash_name == other.hash_name,
+            self.hash == other.hash,
+            set(self.extras) == set(other.extras),
+        ])
+
+    def __ne__(self, other):
+        return not self == other
+
     def keys(self):
         return self.__dict__.keys()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -56,3 +56,4 @@ def test_requirement_files():
             with open(fp[:-4] + '.expected', 'r') as f2:
                 expected = json.loads(f2.read())
                 yield check, open(fp), expected
+

--- a/tests/test_requirement.py
+++ b/tests/test_requirement.py
@@ -1,0 +1,39 @@
+from nose.tools import assert_equal, assert_not_equal
+
+from requirements.requirement import Requirement
+
+
+def get_reqs(requirement_1, requirement_2):
+    return (Requirement.parse(requirement_1),
+            Requirement.parse(requirement_2))
+
+
+def test_simple_equality():
+    assert_equal(*get_reqs("pylib==1.0.0", "pylib==1.0.0"))
+
+
+def test_equality_no_specifiers():
+    assert_equal(*get_reqs("pylib", "pylib"))
+
+
+def test_simple_inequality():
+    assert_not_equal(*get_reqs("pylib==1.0.0", "pylib==1.0.1"))
+
+
+def test_spec_order_equality():
+    """
+    The same specifications, in a different order, are still equal
+    """
+    assert_equal(*get_reqs("pylib>=1.0,<2.0", "pylib<2.0,>=1.0"))
+
+
+def test_vcs_equality():
+    assert_equal(*get_reqs(
+        "-e git://git.example.com/MyProject.git@da39a3ee#egg=MyProject",
+        "-e git://git.example.com/MyProject.git@da39a3ee#egg=MyProject"))
+
+
+def test_vcs_hash_inequality():
+    assert_not_equal(*get_reqs(
+        "-e git://git.example.com/MyProject.git@123#egg=MyProject",
+        "-e git://git.example.com/MyProject.git@abc#egg=MyProject"))


### PR DESCRIPTION
I'm working on a tool for comparing requirements files to one another. ``requirements-parser`` would be a great fit for my project, but I need some simple equality testing so I know when a requirement from one file doesn't match the "equivalent" file from another.

This PR adds equality testing to the Requirement class, along with some basic unit tests.