### PR TITLE
Add setuptools as a install_requires Dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    install_requires=['setuptools'],
     tests_require=['nose'],
     test_suite='nose.collector',
 )


### PR DESCRIPTION
pkg_resources is needed at runtime, lets be explicit and state that so pip etc. do the right thing.